### PR TITLE
Allow empty site_name and site_name_separator

### DIFF
--- a/resources/views/metatags.antlers.html
+++ b/resources/views/metatags.antlers.html
@@ -1,7 +1,7 @@
 {{ if settings | in_array:basic }}
 <!-- BASIC METATAGS-->
 {{ fields }}
-  {{ if basic_title }}<title>{{ basic_title }} {{ extras.site_name_separator}} {{ extras.site_name}}</title>{{ /if }}
+  {{ if basic_title }}<title>{{ basic_title }}{{ extras.site_name_separator}}{{ extras.site_name}}</title>{{ /if }}
   {{ if basic_description }}<meta name="description" content="{{ basic_description }}" />{{ /if }}
   {{ if basic_keywords }}<meta name="keywords" content="{{ basic_keywords | join }}" />{{ /if }}
   {{ if basic_robots }}<meta name="robots" content="{{ basic_robots }}{{ value }}{{ if !last }}, {{ /if }}{{ /basic_robots }}" />{{ /if }}

--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -35,6 +35,8 @@ class SettingsController extends Controller {
     $fields->validate();
 
     $values = Arr::removeNullValues($fields->process()->values()->all());
+    $values['site_name'] = isset($values['site_name']) ? " {$values['site_name']}" : '';
+    $values['site_name_separator'] = isset($values['site_name_separator']) ? " {$values['site_name_separator']} " : '';
 
     Settings::make($values)->save();
 


### PR DESCRIPTION
This PR will allow site_name and site_name_separator to be empty.
Fixes: https://github.com/gioppy/statamic-metatags/issues/5